### PR TITLE
Optimized and improved skyplot and detail views

### DIFF
--- a/lsst_dashboard/gui.py
+++ b/lsst_dashboard/gui.py
@@ -64,11 +64,7 @@ def create_hv_dataset(ddf):
         else:
             vdims.append(c)
 
-    df = (ddf.replace(np.inf, np.nan)
-             .replace(-np.inf, np.nan)
-             .dropna(how='any'))
-
-    return hv.Dataset(df, kdims=kdims, vdims=vdims)
+    return hv.Dataset(ddf, kdims=kdims, vdims=vdims)
 
 
 class Store(object):
@@ -611,7 +607,7 @@ class QuickLookComponent(Component):
             query_expr = self._assemble_query_expression()
 
             if query_expr:
-                ddf = ddf.query(query_expr)
+                ddf = ddf.query(query_expr).persist()
                 filtered_datasets[filter_type] = ddf
 
         return create_hv_dataset(ddf)

--- a/lsst_dashboard/gui.py
+++ b/lsst_dashboard/gui.py
@@ -11,6 +11,7 @@ import param
 import panel as pn
 import holoviews as hv
 import numpy as np
+import dask.array as da
 import dask.dataframe as dd
 
 from holoviews.streams import RangeXY, PlotSize
@@ -49,7 +50,7 @@ filtered_datavisits = []
 sample_data_directory = 'sample_data/DM-23243-KTK-1Perc'
 
 
-def create_hv_dataset(ddf):
+def create_hv_dataset(ddf, percentile=1):
 
     _idNames = ('patch', 'tract')
     _kdims = ('ra', 'dec', 'psfMag', 'label')
@@ -58,18 +59,23 @@ def create_hv_dataset(ddf):
     kdims = []
     vdims = []
     for c in ddf.columns:
-        if (c in _kdims or
-                c in _idNames or
-                c in _flags):
-            if c in ('ra', 'dec'):
+        if (c in _kdims or c in _idNames or c in _flags):
+            if c in ('ra', 'dec', 'psfMag'):
                 cmin, cmax = dd.compute(ddf[c].min(), ddf[c].max())
                 c = hv.Dimension(c, range=(cmin, cmax))
-            elif c == 'label':
+            elif c in ('filter', 'label', 'patch'):
                 cvalues = list(ddf[c].unique())
                 c = hv.Dimension(c, values=cvalues)
+            elif ddf[c].dtype.kind == 'b':
+                c = hv.Dimension(c, values=[True, False])
             kdims.append(c)
         else:
-            cmin, cmax = dd.compute(ddf[c].min(), ddf[c].max())
+            if percentile is not None:
+                p = percentile
+                darray = ddf[c].values
+                cmin, cmax = da.compute(da.percentile(darray, p), da.percentile(darray, 100-p))
+            else:
+                cmin, cmax = dd.compute(ddf[c].min(), ddf[c].max())
             c = hv.Dimension(c, range=(cmin, cmax))
             vdims.append(c)
 
@@ -743,9 +749,12 @@ class QuickLookComponent(Component):
                    '''$( ".metrics-plot-area" ).hide();''')
             self.execute_js_script(cmd)
 
-            self._skyplot_tabs[:] = self.skyplot_list
-            if self._skyplot_tabs not in self.skyplot_layout:
+            if self._skyplot_tabs in self.skyplot_layout:
+                self._skyplot_tabs[:] = self.skyplot_list
+            else:
+                self._skyplot_tabs[:] = []
                 self.skyplot_layout[:] = [self._skyplot_tabs]
+                self._skyplot_tabs[:] = self.skyplot_list
         elif self._switch_view.value == 'Overview':
             self.attempt_to_clear(self.skyplot_layout)
             cmd = ('''$( ".skyplot-plot-area" ).hide();'''

--- a/lsst_dashboard/gui.py
+++ b/lsst_dashboard/gui.py
@@ -11,6 +11,7 @@ import param
 import panel as pn
 import holoviews as hv
 import numpy as np
+import dask.dataframe as dd
 
 from holoviews.streams import RangeXY, PlotSize
 
@@ -60,8 +61,16 @@ def create_hv_dataset(ddf):
         if (c in _kdims or
                 c in _idNames or
                 c in _flags):
+            if c in ('ra', 'dec'):
+                cmin, cmax = dd.compute(ddf[c].min(), ddf[c].max())
+                c = hv.Dimension(c, range=(cmin, cmax))
+            elif c == 'label':
+                cvalues = list(ddf[c].unique())
+                c = hv.Dimension(c, values=cvalues)
             kdims.append(c)
         else:
+            cmin, cmax = dd.compute(ddf[c].min(), ddf[c].max())
+            c = hv.Dimension(c, range=(cmin, cmax))
             vdims.append(c)
 
     return hv.Dataset(ddf, kdims=kdims, vdims=vdims)

--- a/lsst_dashboard/plots.py
+++ b/lsst_dashboard/plots.py
@@ -219,23 +219,37 @@ class scattersky(ParameterizedFunction):
 
     xdim = param.String(default='x', doc="""
         Dimension of the dataset to use as x-coordinate""")
+
     ydim = param.String(default='y0', doc="""
         Dimension of the dataset to use as y-coordinate""")
+
+    xsampling = param.Integer(default=500, doc="""
+        How densely to sample the rasterized plot along the x-axis.""")
+
+    ysampling = param.Integer(default=500, doc="""
+        How densely to sample the rasterized plot along the y-axis.""")
+
+    max_points = param.Integer(default=10000, doc="""
+        Maximum number of points to display before switching to rasterize.""")
+
     scatter_cmap = param.String(default='bgyw', doc="""
         Colormap to use for the scatter plot""")
+
     sky_cmap = param.String(default='bgyw', doc="""
         Colormap to use for the sky plot""")
-    height = param.Number(default=300, doc="""
-        Height in pixels of the combined layout""")
-    width = param.Number(default=625, doc="""
-        Width in pixels of the combined layout""")
-    filter_stream = param.ClassSelector(default=FilterStream(), class_=FilterStream,
-                                        doc="Stream to which selection ranges get added.")
+
+    filter_stream = param.ClassSelector(default=FilterStream(), class_=FilterStream, doc="""
+        Stream to which selection ranges get added.""")
+
     show_rawsky = param.Boolean(default=False, doc="""
-        Whether to show the "unselected" sky points in greyscale when there is a selection.""")
+        Whether to show the "unselected" sky points in greyscale when
+        there is a selection.""")
+
     show_table = param.Boolean(default=False, doc="""
         Whether to show the table next to the plots.""")
+
     sky_range_stream = param.ClassSelector(default=None, class_=RangeXY)
+
     scatter_range_stream = param.ClassSelector(default=None, class_=RangeXY)
 
     # @profile(immediate=True)
@@ -249,71 +263,97 @@ class scattersky(ParameterizedFunction):
         if ('ra' not in dset.dimensions()) or ('dec' not in dset.dimensions()):
             raise ValueError('ra and/or dec not in Dataset.')
 
+        # Compute sampling
+        ra_range = (ra0, ra1) = dset.range('ra')
+        dec_range = (dec0, dec1) = dset.range('dec')
+        ra_sampling = (ra1-ra0)/self.p.xsampling
+        dec_sampling = (dec1-dec0)/self.p.ysampling
+        x_range = (x0, x1) = dset.range(self.p.xdim)
+        y_range = (y0, y1) = dset.range(self.p.ydim)
+        x_sampling = (x1-x0)/self.p.xsampling
+        y_sampling = (y1-y0)/self.p.ysampling
+
         # Set up scatter plot
+        scatter_pts = dset.apply(
+            filterpoints, streams=[self.p.filter_stream],
+            xdim=self.p.xdim, ydim=self.p.ydim
+        )
         scatter_range = RangeXY()
         if self.p.sky_range_stream:
             link_streams(self.p.scatter_range_stream, scatter_range)
         scatter_streams = [scatter_range, PlotSize()]
-        scatter_filterpoints = filterpoints.instance(xdim=self.p.xdim, ydim=self.p.ydim)
-        scatter_pts = hv.util.Dynamic(dset, operation=scatter_filterpoints,
-                                      streams=[self.p.filter_stream])
-        scatter_shaded = datashade(scatter_pts, cmap=viridis, streams=scatter_streams)
-        scatter = dynspread(scatter_shaded).opts(height=self.p.height, responsive=True)
+        scatter_rasterized = rasterize(
+            scatter_pts, streams=scatter_streams, x_sampling=x_sampling,
+            y_sampling=y_sampling
+        ).opts(clim=(1, np.nan), clipping_colors={'min': 'transparent'})
 
         # Set up sky plot
         sky_range = RangeXY()
         if self.p.sky_range_stream:
             link_streams(self.p.sky_range_stream, sky_range)
+        sky_pts = dset.apply(
+            filterpoints, xdim='ra', ydim='dec', set_title=False,
+            streams=[self.p.filter_stream]
+        )
         skyplot_streams = [sky_range, PlotSize()]
-        sky_filterpoints = filterpoints.instance(xdim='ra', ydim='dec', set_title=False)
-        sky_pts = hv.util.Dynamic(dset, operation=sky_filterpoints,
-                                  streams=[self.p.filter_stream])
-        sky = rasterize(sky_pts, aggregator=ds.mean(self.p.ydim), streams=skyplot_streams).opts(
-            bgcolor="black", colorbar=True, cmap='viridis', height=self.p.height, responsive=True)
-        # sky = dynspread(sky_shaded) # Add once supported in Datashader
-
-        # Set up summary table
-        table = hv.util.Dynamic(dset, operation=summary_table.instance(ydim=self.p.ydim),
-                                streams=[self.p.filter_stream])
-        table = table.opts(width=200)
+        sky_rasterize = rasterize.instance(
+            aggregator=ds.mean(self.p.ydim), streams=skyplot_streams,
+            x_sampling=ra_sampling, y_sampling=dec_sampling
+        )
+        sky_rasterized = apply_when(
+            sky_pts, operation=sky_rasterize,
+            predicate=lambda pts: len(pts) > self.p.max_points
+        )
 
         # Set up BoundsXY streams to listen to box_select events and notify FilterStream
-        scatter_select = BoundsXY(source=scatter)
+        scatter_select = BoundsXY(source=scatter_pts)
         scatter_notifier = partial(notify_stream, filter_stream=self.p.filter_stream,
                                    xdim=self.p.xdim, ydim=self.p.ydim)
         scatter_select.add_subscriber(scatter_notifier)
 
-        sky_select = BoundsXY(source=sky)
+        sky_select = BoundsXY(source=sky_pts)
         sky_notifier = partial(notify_stream, filter_stream=self.p.filter_stream,
                                xdim='ra', ydim='dec')
         sky_select.add_subscriber(sky_notifier)
 
         # Reset
-        reset = PlotReset(source=scatter)
+        reset = PlotReset(source=scatter_rasterized)
         reset.add_subscriber(partial(reset_stream, self.p.filter_stream,
                                      [self.p.sky_range_stream,
                                       self.p.scatter_range_stream]))
 
+        raw_scatterpts = filterpoints(dset, xdim=self.p.xdim, ydim=self.p.ydim)
         raw_scatter = datashade(
-            scatter_filterpoints(dset), cmap=list(Greys9[::-1][:5]),
-            streams=scatter_streams
+            raw_scatterpts, cmap=list(Greys9[::-1][:5]), streams=scatter_streams,
+            x_sampling=x_sampling, y_sampling=y_sampling
         )
-
-        scatter_p = (raw_scatter*scatter).options(bgcolor="black")
+        scatter_p = (raw_scatter*scatter_rasterized)
 
         if self.p.show_rawsky:
+            raw_skypts = filterpoints(dset, xdim=self.p.xdim, ydim=self.p.ydim)
             raw_sky = datashade(
-                sky_filterpoints(dset), cmap=list(Greys9[::-1][:5]),
-                streams=skyplot_streams
+                rawskypts, cmap=list(Greys9[::-1][:5]), streams=skyplot_streams,
+                x_sampling=ra_sampling, y_sampling=dec_sampling
             )
-            sky_p = raw_sky*sky
+            sky_p = raw_sky*sky_rasterized
         else:
-            sky_p = sky
+            sky_p = sky_rasterized
 
         if self.p.show_table:
-            return (table + scatter_p + sky_p)
+            table = dset.apply(summary_table, ydim=self.p.ydim, streams=[self.p.filter_stream])
+            table = table.opts()
+            layout = (table + scatter_p + sky_p)
         else:
-            return (scatter_p + sky_p).opts(sizing_mode='stretch_width')
+            layout = (scatter_p + sky_p).opts(sizing_mode='stretch_width')
+
+        return layout.opts(
+            opts.Image(bgcolor="black", colorbar=True, cmap='viridis',
+                       responsive=True, tools=['box_select', 'hover']),
+            opts.Layout(sizing_mode='stretch_width'),
+            opts.Points(color=self.p.ydim, cmap='viridis', tools=['hover']),
+            opts.RGB(alpha=0.5),
+            opts.Table(width=200)
+        )
 
 
 class multi_scattersky(ParameterizedFunction):


### PR DESCRIPTION
This PR makes a variety of improvements to both the skyplot and the detail plot.

Instead of displaying datashaded+dynspread, rasterized and decimated views of the points this PR switches to using a rasterized view with a fixed sampling density (500 pixels by default) and switches to regular points when the data volume is below a certain level (10,000 points by default). This alone speeds up the plots significantly.

The second component of this PR is caching the ranges of the dataframe columns on initialization on the Dimension objects. This prevents HoloViews from computing these ranges over and over again, which it does to be able to normalize ranges across plots and frames (something I will probably look at in HoloViews itself in the near future). It also uses da.percentile when computing the value ranges to drop outliers.

Along with the recent fix to Panel templates which is available since Panel 0.9.4 this should significantly optimize the dashboard.

Note: This PR also includes @brendancol's fix for changing to persist throughout.

- [x] Implements #157 
- [x] Improves #150 by caching ranges and reducing amount of computation
- [x] Fixes #103 

