### PR TITLE
Refactor patitioning, and add partitioning CLI

### DIFF
--- a/lsst_dashboard/dataset.py
+++ b/lsst_dashboard/dataset.py
@@ -11,10 +11,10 @@ from kartothek.io.dask.dataframe import read_dataset_as_ddf
 from storefact import get_store_from_url
 
 
-METADATA_FILENAME = 'dashboard_metadata.yaml'
+METADATA_FILENAME = "dashboard_metadata.yaml"
 
 
-class Dataset():
+class Dataset:
     """
     USAGE:
         d = Dataset(path)
@@ -38,51 +38,47 @@ class Dataset():
 
         self.parse_metadata_from_file()
 
-        print('-- read coadd table --')
+        print("-- read coadd table --")
         self.fetch_coadd_table()  # currently ignoring forced/unforced
 
-        print('-- generate other metadata fields --')
+        print("-- generate other metadata fields --")
         self.post_process_metadata()
 
-        print('-- read visit data --')
+        print("-- read visit data --")
         self.fetch_visits_by_metric()
 
-        print('-- done with reads --')
+        print("-- done with reads --")
 
-    def get_coadd_ddf_by_filter_metric(self, filter_name, metrics,
-                                       tracts, coadd_version='unforced',
-                                       warnings=[]):
+    def get_coadd_ddf_by_filter_metric(
+        self, filter_name, metrics, tracts, coadd_version="unforced", warnings=[]
+    ):
 
         for t in tracts:
             if t not in self.tracts:
-                msg = 'Selected tract {} missing in data'.format(t)
-                print('WARNING: {}'.format(msg))
+                msg = "Selected tract {} missing in data".format(t)
+                print("WARNING: {}".format(msg))
                 warnings.append(msg)
 
         # filter out any tracts not in data
         valid_tracts = list(set(self.tracts).intersection(set(tracts)))
 
         if not valid_tracts:
-            msg = 'No Valid tracts selected...using all tracts'
-            print('WARNING: {}'.format(msg))
+            msg = "No Valid tracts selected...using all tracts"
+            print("WARNING: {}".format(msg))
             valid_tracts = self.tracts
             warnings.append(msg)
 
-        predicates = [[('tract', 'in', valid_tracts),
-                       ('filter', '==', filter_name)]]
+        predicates = [[("tract", "in", valid_tracts), ("filter", "==", filter_name)]]
 
-        dataset = "coadd_{}".format(coadd_version)
+        dataset = "analysisCoaddTable_{}".format(coadd_version)
 
-        columns = metrics + self.flags + ['ra', 'dec', 'filter',
-                                          'psfMag', 'patch']
+        columns = metrics + self.flags + ["ra", "dec", "filter", "psfMag", "patch"]
 
-        store = partial(get_store_from_url, 'hfs://' + str(self.path))
+        store = partial(get_store_from_url, "hfs://" + str(self.path))
 
-        karto_kwargs = dict(predicates=predicates,
-                            dataset_uuid=dataset,
-                            columns=columns,
-                            store=store,
-                            table='table')
+        karto_kwargs = dict(
+            predicates=predicates, dataset_uuid=dataset, columns=columns, store=store, table="table"
+        )
 
         coadd_df = (read_dataset_as_ddf(**karto_kwargs)
                     .repartition(partition_size="4GB")
@@ -94,83 +90,80 @@ class Dataset():
 
         return coadd_df
 
-    def get_patch_count(self, filters, tracts, coadd_version='unforced'):
+    def get_patch_count(self, filters, tracts, coadd_version="unforced"):
 
         return 1
 
         predicates = []
 
         if filters:
-            predicates.append(('filter', 'in', filters))
+            predicates.append(("filter", "in", filters))
 
         if tracts:
-            predicates.append(('tract', 'in', tracts))
+            predicates.append(("tract", "in", tracts))
 
-        dataset = "coadd_{}".format(coadd_version)
+        dataset = "analysisCoaddTable_{}".format(coadd_version)
 
-        columns = ['patch']
+        columns = ["patch"]
 
-        store = partial(get_store_from_url, 'hfs://' + str(self.path))
+        store = partial(get_store_from_url, "hfs://" + str(self.path))
 
         if predicates:
 
-            coadd_df = read_dataset_as_ddf(predicates=[predicates],
-                                           dataset_uuid=dataset,
-                                           columns=columns,
-                                           store=store,
-                                           table='table')
+            coadd_df = read_dataset_as_ddf(
+                predicates=[predicates], dataset_uuid=dataset, columns=columns, store=store, table="table"
+            )
         else:
-            coadd_df = read_dataset_as_ddf(dataset_uuid=dataset,
-                                           columns=columns,
-                                           store=store,
-                                           table='table')
+            coadd_df = read_dataset_as_ddf(dataset_uuid=dataset, columns=columns, store=store, table="table")
 
-
-        return coadd_df.drop_duplicates().count().compute()['patch']
+        return coadd_df.drop_duplicates().count().compute()["patch"]
 
     def parse_metadata_from_file(self):
         if self.path.joinpath(METADATA_FILENAME).exists():
             self.metadata_path = self.path.joinpath(METADATA_FILENAME)
         else:
-            self.metadata_path = Path(os.environ.get('LSST_META', os.curdir)).joinpath(self.path.name, METADATA_FILENAME)
+            self.metadata_path = Path(os.environ.get("LSST_META", os.curdir)).joinpath(
+                self.path.name, METADATA_FILENAME
+            )
 
-        with self.metadata_path.open('r') as f:
+        with self.metadata_path.open("r") as f:
             self.metadata = yaml.load(f, Loader=yaml.SafeLoader)
-            self.failures = self.metadata.get('failures', {})
+            self.failures = self.metadata.get("failures", {})
             if self.tracts is None:
-                self.tracts = list(set(x for v in self.metadata['visits'].values() for x in v.keys()))
+                self.tracts = list(set(x for v in self.metadata["visits"].values() for x in v.keys()))
 
-    def fetch_coadd_table(self, coadd_version='unforced'):
-        table = 'qaDashboardCoaddTable'
-        store = partial(get_store_from_url, 'hfs://' + str(self.path))
+    def fetch_coadd_table(self, coadd_version="unforced"):
+        table = "qaDashboardCoaddTable"
+        store = partial(get_store_from_url, "hfs://" + str(self.path))
         print(str(self.path))
-        predicates = [[('tract', 'in', self.tracts)]]
-        dataset = "coadd_{}".format(coadd_version)
+        predicates = [[("tract", "in", self.tracts)]]
+        dataset = "analysisCoaddTable_{}".format(coadd_version)
 
-        coadd_df = read_dataset_as_ddf(predicates=predicates,
-                                       dataset_uuid=dataset,
-                                       store=store,
-                                       table='table')
+        coadd_df = read_dataset_as_ddf(
+            predicates=predicates, dataset_uuid=dataset, store=store, table="table"
+        )
+
+        # hack label in ...
+        coadd_df["label"] = "star"
 
         self.coadd[table] = coadd_df
 
     def post_process_metadata(self):
-        df = self.coadd['qaDashboardCoaddTable']
+        df = self.coadd["qaDashboardCoaddTable"]
         self.flags = df.columns[df.dtypes == bool].to_list()
-        self.filters = list(self.metadata['visits'].keys())
-        self.metrics = (set(df.columns.to_list()) -
-                        set(self.flags) -
-                        set(['patch', 'dec',
-                             'psfMag', 'ra', 'filter',
-                             'dataset', 'dir0', 'tract']))
+        self.filters = list(self.metadata["visits"].keys())
+        self.metrics = (
+            set(df.columns.to_list())
+            - set(self.flags)
+            - set(["patch", "dec", "label", "psfMag", "ra", "filter", "dataset", "dir0", "tract"])
+        )
 
     def fetch_visits(self):
-        store = partial(get_store_from_url, 'hfs://' + str(self.path))
-        predicates = [[('tract', 'in', self.tracts)]]
-        self.visits = read_dataset_as_ddf(predicates=predicates,
-                                          dataset_uuid='visits',
-                                          store=store,
-                                          table='table')
+        store = partial(get_store_from_url, "hfs://" + str(self.path))
+        predicates = [[("tract", "in", self.tracts)]]
+        self.visits = read_dataset_as_ddf(
+            predicates=predicates, dataset_uuid="analysisVisitTable", store=store, table="table"
+        )
 
     def get_visits_by_metric_filter(self, filt, metric):
 
@@ -180,11 +173,35 @@ class Dataset():
                    'calib_psf_candidate', 'calib_photometry_reserved',
                    'qaBad_flag', 'ra', 'dec', 'psfMag'] + [metric]
 
-        visits_ddf = read_dataset_as_ddf(dataset_uuid="visits",
+        visits_ddf = read_dataset_as_ddf(dataset_uuid="analysisVisitTable",
                                          predicates=[[('filter', '==', filt)]],
                                          store=store,
                                          columns=columns,
                                          table='table')
+        store = partial(get_store_from_url, "hfs://" + str(self.path))
+
+        columns = [
+            "filter",
+            "tract",
+            "visit",
+            "calib_psf_used",
+            "calib_psf_candidate",
+            "calib_photometry_reserved",
+            "qaBad_flag",
+            "ra",
+            "dec",
+            "psfMag",
+        ] + [metric]
+
+        visits_ddf = read_dataset_as_ddf(
+            dataset_uuid="analysisVisitTable",
+            predicates=[[("filter", "==", filt)]],
+            store=store,
+            columns=columns,
+            table="table",
+        )
+        # hack label in ...
+        visits_ddf["label"] = "star"
 
         return visits_ddf[visits_ddf[metric].notnull()]
 
@@ -195,7 +212,8 @@ class Dataset():
                 try:
                     ddf = self.get_visits_by_metric_filter(filt, metric)
                 except:
-                    print('WARNING: problem loading visits for {} metric and {} filter'.format(metric, filt))
+                    # raise
+                    print("WARNING: problem loading visits for {} metric and {} filter".format(metric, filt))
                     ddf = None
 
                 self.visits_by_metric[filt][metric] = ddf

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,24 @@
 import setuptools
-__name__ == "__main__" and setuptools.setup(**dict(
-    name="lsst_dashboard",
-    version='v0.0.2a',
-    author="quansight",
-    author_email="tony.fast@quansight.com",
-    description="Conventions for writing code in the notebook.",
-    long_description_content_type='text/markdown',
-    url="https://github.com/quanisght/lsst_dashboard",
-    python_requires=">=3.6",
-    license="BSD-3-Clause",
-    install_requires=[],
-    include_package_data=True,
-    packages=setuptools.find_packages(),
-    entry_points={
-          'console_scripts': [
-              'lsst_data_explorer = lsst_dashboard.__main__:main'
-          ]
-    })
+
+__name__ == "__main__" and setuptools.setup(
+    **dict(
+        name="lsst_dashboard",
+        version="v0.0.2a",
+        author="quansight",
+        author_email="tony.fast@quansight.com",
+        description="Conventions for writing code in the notebook.",
+        long_description_content_type="text/markdown",
+        url="https://github.com/quanisght/lsst_dashboard",
+        python_requires=">=3.6",
+        license="BSD-3-Clause",
+        install_requires=[],
+        include_package_data=True,
+        packages=setuptools.find_packages(),
+        entry_points={
+            "console_scripts": [
+                "lsst_data_explorer = lsst_dashboard.__main__:main",
+                "lsst_data_repartition = lsst_dashboard.__main__:repartition",
+            ]
+        },
+    )
 )


### PR DESCRIPTION
This update creates a new `DatasetPartitioner` object, which manages the repartitioning of butler-read data into kartothek datasets, as well as writing tables of summary statistics. This also adds a `lsst_data_repartition` CLI, which does both the repartitioning and the writing of stats summaries. The only changes necessary to the dashboard code are renaming the datasets in the kartothek reads, as the dataset names now match the original butler dataset names.  