### PR TITLE
Ease memory usage by repartitioning one filter at a time

### DIFF
--- a/lsst_dashboard/__main__.py
+++ b/lsst_dashboard/__main__.py
@@ -7,7 +7,7 @@ import os
 from dask.distributed import Client, LocalCluster
 
 hostname = socket.gethostname()
-host = hostname.split('.')[0]
+host = hostname.split(".")[0]
 username = getpass.getuser()
 
 # dask ports need to be between 29000 and 29999 (hard requirement due to firewall constraints)
@@ -19,6 +19,7 @@ DASK_ALLOWED_PORTS = (29000, 30000)
 DASK_DASHBOARD_ALLOWED_PORTS = (20000, 20500)
 DASHBOARD_ALLOWED_PORTS = (20500, 21000)
 
+
 def find_available_ports(n, start, stop):
     count = 0
     for port in range(start, stop):
@@ -26,7 +27,7 @@ def find_available_ports(n, start, stop):
             if count >= n:
                 return
             try:
-                res = sock.bind(('localhost', port))
+                res = sock.bind(("localhost", port))
                 count += 1
                 yield port
             except OSError:
@@ -34,52 +35,57 @@ def find_available_ports(n, start, stop):
 
 
 @click.command()
-@click.option('--queue', default='debug', help='Slurm Queue to use (default=debug), ignored when on local machine')
-@click.option('--nodes', default=2, help='Number of compute nodes to launch (default=2), ignored when on local machine')
-@click.option('--localcluster', is_flag=True, help='Launches a localcluster instead of slurmcluster')
+@click.option(
+    "--queue", default="debug", help="Slurm Queue to use (default=debug), ignored when on local machine"
+)
+@click.option(
+    "--nodes", default=2, help="Number of compute nodes to launch (default=2), ignored when on local machine"
+)
+@click.option("--localcluster", is_flag=True, help="Launches a localcluster instead of slurmcluster")
 def main(queue, nodes, localcluster):
-    if 'lsst-dev' in host and not localcluster:
+    if "lsst-dev" in host and not localcluster:
         from dask_jobqueue import SLURMCluster
 
-        scheduler_port, = find_available_ports(1, *DASK_ALLOWED_PORTS)
-        lsst_dashboard_port, = find_available_ports(1, *DASHBOARD_ALLOWED_PORTS)
-        dask_dashboard_port, = find_available_ports(1, *DASK_DASHBOARD_ALLOWED_PORTS)
+        (scheduler_port,) = find_available_ports(1, *DASK_ALLOWED_PORTS)
+        (lsst_dashboard_port,) = find_available_ports(1, *DASHBOARD_ALLOWED_PORTS)
+        (dask_dashboard_port,) = find_available_ports(1, *DASK_DASHBOARD_ALLOWED_PORTS)
 
-        print(f'...starting dask cluster using slurm on {host} (queue={queue})')
+        print(f"...starting dask cluster using slurm on {host} (queue={queue})")
         cluster = SLURMCluster(
             queue=queue,
             cores=24,
             processes=6,
-            memory='128GB',
+            memory="128GB",
             scheduler_port=scheduler_port,
             extra=[f'--worker-port {":".join(str(p) for p in DASK_ALLOWED_PORTS)}'],
-            dashboard_address=f':{dask_dashboard_port}',
+            dashboard_address=f":{dask_dashboard_port}",
         )
 
-        print(f'...requesting {nodes} nodes')
+        print(f"...requesting {nodes} nodes")
         cluster.scale(nodes)
         client = Client(cluster)
-        print('...waiting for at least one node')
+        print("...waiting for at least one node")
         client.wait_for_workers(1)
 
         # currently local and server ports need to match
         LOCAL_DASHBOARD = lsst_dashboard_port
         LOCAL_DASK_DASHBOARD = dask_dashboard_port
 
-        print('...starting dashboard')
-        print('run the command below from your local machine to view dashboard:')
-        print(f'\nssh -N -L {LOCAL_DASHBOARD}:{host}:{lsst_dashboard_port} -L {LOCAL_DASK_DASHBOARD}:{host}:{dask_dashboard_port} {username}@{hostname}\n')
+        print("...starting dashboard")
+        print("run the command below from your local machine to view dashboard:")
+        print(
+            f"\nssh -N -L {LOCAL_DASHBOARD}:{host}:{lsst_dashboard_port} -L {LOCAL_DASK_DASHBOARD}:{host}:{dask_dashboard_port} {username}@{hostname}\n"
+        )
     else:
         LOCAL_DASHBOARD = 52001
         LOCAL_DASK_DASHBOARD = 52002
 
-        print(f'starting local dask cluster on {host}')
-        cluster = LocalCluster(dashboard_address=f':{LOCAL_DASK_DASHBOARD}')
+        print(f"starting local dask cluster on {host}")
+        cluster = LocalCluster(dashboard_address=f":{LOCAL_DASK_DASHBOARD}")
         client = Client(cluster)
 
-
-    print(f'### lsst dashboard available at http://localhost:{LOCAL_DASHBOARD} ###')
-    print(f'### dask dashboard available at http://localhost:{LOCAL_DASK_DASHBOARD} ###')
+    print(f"### lsst dashboard available at http://localhost:{LOCAL_DASHBOARD} ###")
+    print(f"### dask dashboard available at http://localhost:{LOCAL_DASK_DASHBOARD} ###")
 
     from lsst_dashboard.gui import dashboard
 
@@ -104,11 +110,33 @@ def main(queue, nodes, localcluster):
 @click.option("--localcluster", is_flag=True, help="Launches a localcluster instead of slurmcluster")
 def repartition(butlerpath, destination, queue, nodes, localcluster):
     if "lsst-dev" in host and not localcluster:
+        # from dask_jobqueue import SLURMCluster
+
+        # scheduler_port, worker_port = find_available_ports(2, *DASK_ALLOWED_PORTS)
+        # (dask_dashboard_port,) = find_available_ports(1, *DASK_DASHBOARD_ALLOWED_PORTS)
+
+        # print(f"...starting dask cluster using slurm on {host} (queue={queue})")
+        # cluster = SLURMCluster(
+        #     queue=queue,
+        #     cores=24,
+        #     memory="128GB",
+        #     scheduler_port=scheduler_port,
+        #     extra=[f"--worker-port {worker_port}"],
+        #     dashboard_address=f":{dask_dashboard_port}",
+        # )
+
+        # print(f"...requesting {nodes} nodes")
+        # cluster.scale(nodes)
+        # client = Client(cluster)
+        # print(f"...waiting for at least {waitfor} workers")
+        # client.wait_for_workers(waitfor)
+
         from dask_jobqueue import SLURMCluster
 
         scheduler_port, worker_port = find_available_ports(2, *DASK_ALLOWED_PORTS)
         (dask_dashboard_port,) = find_available_ports(1, *DASK_DASHBOARD_ALLOWED_PORTS)
 
+        print(f"...starting dask cluster using slurm on {host} (queue={queue})")
         print(f"...starting dask cluster using slurm on {host} (queue={queue})")
         cluster = SLURMCluster(
             queue=queue,
@@ -122,8 +150,8 @@ def repartition(butlerpath, destination, queue, nodes, localcluster):
         print(f"...requesting {nodes} nodes")
         cluster.scale(nodes)
         client = Client(cluster)
-        print("...waiting for at least one node")
-        client.wait_for_workers(1)
+        print(f"...waiting for {nodes} nodes")
+        client.wait_for_workers(nodes)
 
         # currently local and server ports need to match
         LOCAL_DASK_DASHBOARD = dask_dashboard_port

--- a/lsst_dashboard/__main__.py
+++ b/lsst_dashboard/__main__.py
@@ -170,13 +170,13 @@ def repartition(butlerpath, destination, queue, nodes, localcluster):
     if destination is None:
         destination = f"{butlerpath}/ktk"
 
-    # coadd_forced = CoaddForcedPartitioner(butlerpath, destination)
-    # coadd_forced.partition()
-    # coadd_forced.write_stats()
+    coadd_forced = CoaddForcedPartitioner(butlerpath, destination)
+    coadd_forced.partition()
+    coadd_forced.write_stats()
 
-    # coadd_unforced = CoaddUnforcedPartitioner(butlerpath, destination)
-    # coadd_unforced.partition()
-    # coadd_unforced.write_stats()
+    coadd_unforced = CoaddUnforcedPartitioner(butlerpath, destination)
+    coadd_unforced.partition()
+    coadd_unforced.write_stats()
 
     visits = VisitPartitioner(butlerpath, destination)
     visits.partition()

--- a/lsst_dashboard/__main__.py
+++ b/lsst_dashboard/__main__.py
@@ -170,13 +170,13 @@ def repartition(butlerpath, destination, queue, nodes, localcluster):
     if destination is None:
         destination = f"{butlerpath}/ktk"
 
-    coadd_forced = CoaddForcedPartitioner(butlerpath, destination)
-    coadd_forced.partition()
-    coadd_forced.write_stats()
+    # coadd_forced = CoaddForcedPartitioner(butlerpath, destination)
+    # coadd_forced.partition()
+    # coadd_forced.write_stats()
 
-    coadd_unforced = CoaddUnforcedPartitioner(butlerpath, destination)
-    coadd_unforced.partition()
-    coadd_unforced.write_stats()
+    # coadd_unforced = CoaddUnforcedPartitioner(butlerpath, destination)
+    # coadd_unforced.partition()
+    # coadd_unforced.write_stats()
 
     visits = VisitPartitioner(butlerpath, destination)
     visits.partition()

--- a/lsst_dashboard/partition.py
+++ b/lsst_dashboard/partition.py
@@ -90,7 +90,13 @@ class DatasetPartitioner(object):
             dataId for dataId in self.iter_dataId() if self.butler.datasetExists(self.dataset, dataId)
         ]
 
+        self.filters = [filt for filt in self.metadata["visits"].keys()]
+        self.dataIds_by_filter = {
+            filt: [d for d in self.dataIds if d["filter"] == filt] for filt in self.filters
+        }
+
         self._filenames = None
+        self._filenames_by_filter = None
 
     def __getstate__(self):
         d = self.__dict__
@@ -123,10 +129,19 @@ class DatasetPartitioner(object):
     def filenames(self):
         if self._filenames is None:
             filenames = []
+            filenames_by_filter = {filt: [] for filt in self.filters}
             for dataId in tqdm(self.dataIds, desc=f"Getting filenames for {self.dataset} from Butler"):
-                filenames.append(self.butler.get(self.dataset, **dataId).filename)
+                filename = self.butler.get(self.dataset, **dataId).filename
+                filenames.append(filename)
+                filenames_by_filter[dataId["filter"]].append(filename)
             self._filenames = filenames
+            self._filenames_by_filter = filenames_by_filter
         return self._filenames
+
+    @property
+    def filenames_by_filter(self):
+        self.filenames
+        return self._filenames_by_filter
 
     def normalize_df(self, df):
         """
@@ -135,8 +150,8 @@ class DatasetPartitioner(object):
 
         # TODO I think the partitioning destroys the original indexing if the index numbers are inportant we may need to do a reset_index()
 
-        if self.sample_frac:
-            df = df.sample(frac=self.sample_frac)
+        # if self.sample_frac:
+        #     df = df.sample(frac=self.sample_frac)
         df = df.assign(
             ra=da.rad2deg(df.coord_ra),
             dec=da.rad2deg(df.coord_dec),
@@ -145,6 +160,7 @@ class DatasetPartitioner(object):
 
         del df["coord_ra"]
         del df["coord_dec"]
+
         df = df.rename(columns={"patchId": "patch", "ccdId": "ccd"})
 
         #         categories = list(self.categories)
@@ -159,20 +175,41 @@ class DatasetPartitioner(object):
         return getFlags()
 
     def get_columns(self):
+        # return None
         return list(
             set(self.get_metric_columns() + self.get_flag_columns() + ["coord_ra", "coord_dec", "patchId"])
         )
 
-    def get_df(self):
+    def get_df(self, filt):
+        dataIds = self.dataIds_by_filter[filt]
+        filenames = self.filenames_by_filter[filt]
+
         columns = self.get_columns()
 
         dfs = []
-        for filename, dataId in zip(self.filenames, self.dataIds):
+        for filename, dataId in tqdm(
+            zip(filenames, dataIds),
+            desc=f"Building dask dataframe for {self.dataset} ({filt})",
+            total=len(dataIds),
+        ):
             df = delayed(pd.read_parquet(filename, columns=columns, engine=self.engine))
             df = delayed(pd.DataFrame.assign)(df, **dataId)
             dfs.append(df)
 
-        return self.normalize_df(dd.from_delayed(dfs))
+        if dfs:
+            df = dd.from_delayed(dfs)
+
+            categories = list(self.categories)
+            df = df.categorize(columns=categories)
+
+            if self.sample_frac:
+                df = df.sample(frac=self.sample_frac)
+
+            df = self.normalize_df(df)
+
+            return df
+        else:
+            return None
 
     @property
     def ktk_kwargs(self):
@@ -186,13 +223,18 @@ class DatasetPartitioner(object):
             partition_on=self.partition_on,
         )
 
-    def partition(self):
+    def partition_filt(self, filt):
         """Write partitioned dataset using kartothek
         """
-        df = self.get_df()
-        print(f"... ...ktk repartitioning {self.dataset}")
-        graph = update_dataset_from_ddf(df, **self.ktk_kwargs)
-        graph.compute()
+        df = self.get_df(filt)
+        if df is not None:
+            print(f"... ...ktk repartitioning {self.dataset} ({filt})")
+            graph = update_dataset_from_ddf(df, **self.ktk_kwargs)
+            graph.compute()
+
+    def partition(self):
+        for filt in self.filters:
+            self.partition_filt(filt)
 
     def load_from_ktk(self, predicates, columns=None, dask=True):
         ktk_kwargs = dict(
@@ -222,16 +264,14 @@ class DatasetPartitioner(object):
                 return pd.DataFrame()
 
     def describe_dataId(self, dataId, dask=False, **kwargs):
-        df = self.load_dataId(dataId, columns=self.get_metric_columns(), dask=dask)
+        df = self.load_dataId(dataId, dask=dask)
         return df.replace(np.inf, np.nan).replace(-np.inf, np.nan).dropna(how="any").describe(**kwargs)
 
     def get_stats_list(self, dataIds=None):
         if dataIds is None:
             dataIds = self.dataIds
 
-        fn = partial(
-            describe_dataId, store=self.store, dataset=self.dataset, columns=self.get_metric_columns()
-        )
+        fn = partial(describe_dataId, store=self.store, dataset=self.dataset)
 
         client = dask.distributed.client.default_client()
 
@@ -302,8 +342,8 @@ class VisitPartitioner(DatasetPartitioner):
             }
         )
 
-    def get_columns(self):
-        return super().get_columns() + ["ccdId", "filter", "tract", "visit"]
+    # def get_columns(self):
+    #     return super().get_columns() + ["ccdId", "filter", "tract", "visit"]
 
     def iter_dataId(self):
         d = self.metadata

--- a/lsst_dashboard/partition.py
+++ b/lsst_dashboard/partition.py
@@ -342,8 +342,8 @@ class VisitPartitioner(DatasetPartitioner):
             }
         )
 
-    # def get_columns(self):
-    #     return super().get_columns() + ["ccdId", "filter", "tract", "visit"]
+    def get_columns(self):
+        return super().get_columns() + ["ccdId", "filter", "tract", "visit"]
 
     def iter_dataId(self):
         d = self.metadata


### PR DESCRIPTION
This is in preparation for an eventual goal to repartition the *whole original* tables, so that any column can be loaded upon request.  This is not yet totally functional (still using too much RAM), so the old getMetrics behavior is still active, but the chunking-by-filter behavior is in here.