### PR TITLE
Add drill down view

### DIFF
--- a/lsst_dashboard/dataset.py
+++ b/lsst_dashboard/dataset.py
@@ -1,5 +1,7 @@
+import operator
 import yaml
-from functools import partial
+
+from functools import partial, reduce
 from pathlib import Path
 
 import dask.dataframe as dd
@@ -146,13 +148,13 @@ class Dataset:
             - set(["patch", "dec", "psfMag", "ra", "filter", "dataset", "tract"])
         )
 
-    def get_visits_by_metric_filter(self, filt, metric, visit=None):
+    def get_visits_by_metric_filter(self, filt, metrics, visit=None):
 
         store = partial(get_store_from_url, 'hfs://' + str(self.path))
 
         columns = ['filter', 'tract', 'visit', 'calib_psf_used',
                    'calib_psf_candidate', 'calib_photometry_reserved',
-                   'qaBad_flag', 'ra', 'dec', 'psfMag'] + [metric]
+                   'qaBad_flag', 'ra', 'dec', 'psfMag'] + metrics
 
         if visit:
             predicates = [[('filter', '==', filt), ('visit', '==', visit)]]
@@ -172,7 +174,7 @@ class Dataset:
             "ra",
             "dec",
             "psfMag",
-        ] + [metric]
+        ] + metrics
 
         visits_ddf = read_dataset_as_ddf(
             dataset_uuid="analysisVisitTable",
@@ -182,14 +184,15 @@ class Dataset:
             table="table",
         )
 
-        return visits_ddf[visits_ddf[metric].notnull()]
+        filters = reduce(operator.and_, (visits_ddf[m].notnull() for m in metrics))
+        return visits_ddf[filters]
 
     def fetch_visits_by_metric(self):
         for filt in self.filters:
             self.visits_by_metric[filt] = {}
             for metric in self.metrics:
                 try:
-                    ddf = self.get_visits_by_metric_filter(filt, metric)
+                    ddf = self.get_visits_by_metric_filter(filt, [metric])
                 except:
                     # raise
                     print("WARNING: problem loading visits for {} metric and {} filter".format(metric, filt))

--- a/lsst_dashboard/gui.py
+++ b/lsst_dashboard/gui.py
@@ -691,8 +691,14 @@ class QuickLookComponent(Component):
                 errors = []
                 top_plot = visits_plot(
                     dvisits, self.selected_metrics_by_filter,
-                    filt, errors, self._visits_selections
+                    filt, errors, selections=self._visits_selections
                 )
+                if selection.values and self.coadd_toggle:
+                    title = 'Visit View %s' % selection.values[0]
+                else:
+                    title = 'Coadd View'
+                top_plot.opts(title=title)
+
                 if errors:
                     msg = 'exhibiting metrics {} failed'
                     msg = msg.format(' '.join(errors))

--- a/lsst_dashboard/gui.py
+++ b/lsst_dashboard/gui.py
@@ -20,7 +20,7 @@ from .base import Application
 from .base import Component
 
 from .visits_plot import visits_plot
-from .plots import FilterStream, scattersky, skyplot
+from .plots import FilterStream, Selection, link_streams, scattersky, skyplot
 
 from .dataset import Dataset
 
@@ -46,7 +46,7 @@ filtered_datasets = []
 datavisits = []
 filtered_datavisits = []
 
-sample_data_directory = 'sample_data/DM-23243-KTK-1Perc'
+sample_data_directory = 'sample_data/DM-21335-New2-KTK-1Perc'
 
 
 def create_hv_dataset(ddf, stats, percentile=(1, 99)):
@@ -266,9 +266,17 @@ class QuickLookComponent(Component):
         self.list_layout = pn.Column(sizing_mode='stretch_width')
         self.detail_plots_layout = pn.Column(sizing_mode='stretch_width')
 
+        self.coadd_toggle = pn.widgets.RadioButtonGroup(
+            options=['Coadd View', 'Visit View'], disabled=True,
+            align='end', margin=(5, 0), width=250
+        )
+        self.coadd_toggle.param.watch(self._update_selected_metrics_by_filter, ['value'])
+
         self._filter_streams = {}
         self._skyplot_range_stream = RangeXY()
         self._scatter_range_stream = RangeXY()
+
+        self._visits_selections = {}
 
         self._update(None)
 
@@ -587,7 +595,7 @@ class QuickLookComponent(Component):
 
         return query_expr
 
-    def get_dataset_by_filter(self, filter_type, metrics):
+    def get_dataset_by_filter(self, filter_type, metrics, visits=None):
         global datasets
         global filtered_datasets
 
@@ -638,9 +646,19 @@ class QuickLookComponent(Component):
         self.add_status_message(title,
                                 msg_body, level=level, duration=10)
 
+    def _toggle_coadd_view(self, **kwargs):
+        for stream in self._visits_selections.values():
+            if stream.values:
+                kwargs = {'disabled': False}
+                if self.coadd_toggle.disabled:
+                    kwargs['value'] = 'Visit View'
+                self.coadd_toggle.set_param(**kwargs)
+                return
+        self.coadd_toggle.set_param(disabled=True, value='Coadd View')
+
     @param.depends('selected_metrics_by_filter', watch=True)
     # @profile(immediate=True)
-    def _update_selected_metrics_by_filter(self):
+    def _update_selected_metrics_by_filter(self, *args):
         skyplot_list = []
         detail_plots = {}
         existing_skyplots = {}
@@ -650,12 +668,30 @@ class QuickLookComponent(Component):
             plots_list = []
             if not metrics:
                 continue
+
+            for metric in metrics:
+                key = (filt, metric)
+                if key in self._visits_selections:
+                    selection = self._visits_selections[key]
+                else:
+                    selection = Selection(dimension=0)
+                    selection.add_subscriber(self._toggle_coadd_view, 0.1)
+                    self._visits_selections[key] = selection
+                    streams = []
+                    for (f, m), stream in self._visits_selections.items():
+                        if f != filt:
+                            continue
+                        # Reset links
+                        stream._subscribers = stream._subscribers[:1]
+                        streams.append(stream)
+                    link_streams(*streams)
+
             top_plot = None
             try:
                 errors = []
                 top_plot = visits_plot(
                     dvisits, self.selected_metrics_by_filter,
-                    filt, errors
+                    filt, errors, self._visits_selections
                 )
                 if errors:
                     msg = 'exhibiting metrics {} failed'
@@ -673,7 +709,7 @@ class QuickLookComponent(Component):
                 filter_stream = self._filter_streams[filt]
             else:
                 self._filter_streams[filt] = filter_stream = FilterStream()
-            dset = self.get_dataset_by_filter(filt, metrics=metrics)
+            dset = self.get_dataset_by_filter(filt, metrics, selection.values)
             for i, metric in enumerate(metrics):
                 # Sky plots
                 skyplot_name = filt + ' - ' + metric
@@ -760,7 +796,7 @@ class QuickLookComponent(Component):
             self._plot_top[:] = [self.plot_top]
             self.list_layout[:] = [p for _, p in self.plots_list]
             self._plot_layout[:] = [self.list_layout]
-            self.detail_plots_layout[:] = [self._detail_tabs]
+            self.detail_plots_layout[:] = [self.coadd_toggle, self._detail_tabs]
 
     def on_tracts_updated(self, tracts):
 

--- a/lsst_dashboard/gui.py
+++ b/lsst_dashboard/gui.py
@@ -63,7 +63,7 @@ def create_hv_dataset(ddf, stats, percentile=(1, 99)):
             if c in ('ra', 'dec', 'psfMag'):
                 cmin, cmax = stats[c]['min'].min(), stats[c]['max'].max()
                 c = hv.Dimension(c, range=(cmin, cmax))
-            elif c in ('filter', 'patch'):
+            elif c in ('filter', 'patch', 'tract'):
                 cvalues = list(ddf[c].unique())
                 c = hv.Dimension(c, values=cvalues)
             elif ddf[c].dtype.kind == 'b':
@@ -72,7 +72,7 @@ def create_hv_dataset(ddf, stats, percentile=(1, 99)):
         else:
             if percentile is not None:
                 p0, p1 = percentile
-                if f'{p0}%' in stats.index and f'{p1}%' in stats.index:
+                if c in stats.columns and f'{p0}%' in stats.index and f'{p1}%' in stats.index:
                     cmin, cmax = stats[c][f'{p0}%'].min(), stats[c][f'{p1}%'].max()
                 else:
                     print('percentiles not found in stats, computing')
@@ -266,12 +266,7 @@ class QuickLookComponent(Component):
         self.list_layout = pn.Column(sizing_mode='stretch_width')
         self.detail_plots_layout = pn.Column(sizing_mode='stretch_width')
 
-        self.coadd_toggle = pn.widgets.RadioButtonGroup(
-            options=['Coadd View', 'Visit View'], disabled=True,
-            align='end', margin=(5, 0), width=250
-        )
-        self.coadd_toggle.param.watch(self._update_selected_metrics_by_filter, ['value'])
-
+        self._coadd_toggles = {}
         self._filter_streams = {}
         self._skyplot_range_stream = RangeXY()
         self._scatter_range_stream = RangeXY()
@@ -599,19 +594,27 @@ class QuickLookComponent(Component):
         global datasets
         global filtered_datasets
 
-        warnings = []
-        ddf = (self.store
+        if visits:
+            visit = int(visits[0])
+            ddf = (self.store
                    .active_dataset
-                   .get_coadd_ddf_by_filter_metric(filter_type,
-                                                   metrics=metrics,
-                                                   tracts=self.store.active_tracts,
-                                                   coadd_version=self.store.active_dataset.coadd_version,
-                                                   warnings=warnings))
-        if warnings:
-            msg = ';'.join(warnings)
-            self.add_status_message('Selected Tracts Warning',
-                                    msg, level='error')
-
+                   .get_visits_by_metric_filter(filter_type, metrics, visit)
+                   .persist())
+        else:
+            warnings = []
+            ddf = (self.store
+                   .active_dataset
+                   .get_coadd_ddf_by_filter_metric(
+                       filter_type,
+                       metrics=metrics,
+                       tracts=self.store.active_tracts,
+                       coadd_version=self.store.active_dataset.coadd_version,
+                       warnings=warnings)
+            )
+            if warnings:
+                msg = ';'.join(warnings)
+                self.add_status_message('Selected Tracts Warning',
+                                        msg, level='error')
 
         datasets[filter_type] = ddf
         filtered_datasets[filter_type] = ddf
@@ -646,15 +649,24 @@ class QuickLookComponent(Component):
         self.add_status_message(title,
                                 msg_body, level=level, duration=10)
 
-    def _toggle_coadd_view(self, **kwargs):
+
+    def _reset_visits(self, filt, event):
+        if event.new != 'Coadd View':
+            return
+        for sel in self._visits_selections.values():
+            sel.update(values=[], index=[])
+        self._coadd_toggles[filt].disabled = True
+
+    def _toggle_coadd_view(self, filt, **kwargs):
+        toggle = self._coadd_toggles[filt]
         for stream in self._visits_selections.values():
             if stream.values:
                 kwargs = {'disabled': False}
-                if self.coadd_toggle.disabled:
+                if toggle.disabled:
                     kwargs['value'] = 'Visit View'
-                self.coadd_toggle.set_param(**kwargs)
+                toggle.set_param(**kwargs)
                 return
-        self.coadd_toggle.set_param(disabled=True, value='Coadd View')
+        toggle.set_param(disabled=True, value='Coadd View')
 
     @param.depends('selected_metrics_by_filter', watch=True)
     # @profile(immediate=True)
@@ -675,7 +687,7 @@ class QuickLookComponent(Component):
                     selection = self._visits_selections[key]
                 else:
                     selection = Selection(dimension=0)
-                    selection.add_subscriber(self._toggle_coadd_view, 0.1)
+                    selection.add_subscriber(partial(self._toggle_coadd_view, filt), 0.1)
                     self._visits_selections[key] = selection
                     streams = []
                     for (f, m), stream in self._visits_selections.items():
@@ -686,6 +698,16 @@ class QuickLookComponent(Component):
                         streams.append(stream)
                     link_streams(*streams)
 
+            if filt not in self._coadd_toggles:
+                self._coadd_toggles[filt] = toggle = pn.widgets.RadioButtonGroup(
+                    options=['Coadd View', 'Visit View'], disabled=True,
+                    align='end', margin=(5, 0), width=250
+                )
+                toggle.param.watch(partial(self._reset_visits, filt), ['value'])
+                toggle.param.watch(self._update_selected_metrics_by_filter, ['value'])
+            else:
+                toggle = self._coadd_toggles[filt]
+
             top_plot = None
             try:
                 errors = []
@@ -693,7 +715,7 @@ class QuickLookComponent(Component):
                     dvisits, self.selected_metrics_by_filter,
                     filt, errors, selections=self._visits_selections
                 )
-                if selection.values and self.coadd_toggle:
+                if selection.values and toggle:
                     title = 'Visit View %s' % selection.values[0]
                 else:
                     title = 'Coadd View'
@@ -709,7 +731,7 @@ class QuickLookComponent(Component):
                                             '', e)
 
             self.plot_top = top_plot
-            detail_plots[filt] = [top_plot]
+            detail_plots[filt] = [toggle, top_plot]
 
             if filt in self._filter_streams:
                 filter_stream = self._filter_streams[filt]
@@ -802,7 +824,7 @@ class QuickLookComponent(Component):
             self._plot_top[:] = [self.plot_top]
             self.list_layout[:] = [p for _, p in self.plots_list]
             self._plot_layout[:] = [self.list_layout]
-            self.detail_plots_layout[:] = [self.coadd_toggle, self._detail_tabs]
+            self.detail_plots_layout[:] = [self._detail_tabs]
 
     def on_tracts_updated(self, tracts):
 

--- a/lsst_dashboard/plots.py
+++ b/lsst_dashboard/plots.py
@@ -18,9 +18,9 @@ from holoviews.core.operation import Operation
 from holoviews.core.util import isfinite
 from holoviews.operation.element import apply_when
 from holoviews.streams import (
-    BoundsXY, LinkedStream, PlotReset, PlotSize, RangeXY, Stream
+    BoundsXY, LinkedStream, PlotReset, PlotSize, RangeXY, Selection1D, Stream
 )
-from holoviews.plotting.bokeh.callbacks import Callback
+from holoviews.plotting.bokeh.callbacks import Callback, Selection1DCallback
 from holoviews.plotting.util import process_cmap
 
 from holoviews.operation.datashader import datashade
@@ -64,6 +64,42 @@ class FilterStream(Stream):
     bad_flags = param.List(default=[], doc="""
         Flags to ignore""")
 
+
+class Selection(Selection1D):
+    """
+    A stream representing the selection along a column of values on
+    the source element.
+    """
+
+    index = param.List(default=[], allow_None=True, constant=True)
+
+    values = param.List(default=[], allow_None=True, constant=True)
+
+    def __init__(self, **params):
+        if 'dimension' not in params:
+            raise ValueError("Must define a dimension to select values on.")
+        self.dimension = params.pop('dimension')
+        super(Selection, self).__init__(**params)
+
+
+class SelectionCallback(Selection1DCallback):
+
+    def _process_msg(self, msg):
+        msg = super()._process_msg(msg)
+        if 'index' in msg:
+            el = self.plot.current_frame
+            stream = self.streams[0]
+            if len(msg['index']):
+                selection = el.iloc[msg['index']]
+                values = selection.dimension_values(stream.dimension)
+                msg['values'] = list(values)
+            else:
+                msg['values'] = []
+        return msg
+
+
+callbacks = Stream._callbacks['bokeh']
+callbacks[Selection] = SelectionCallback
 
 class FlagSetter(Stream):
     """Stream for setting flags

--- a/lsst_dashboard/plots.py
+++ b/lsst_dashboard/plots.py
@@ -90,9 +90,9 @@ class SelectionCallback(Selection1DCallback):
             el = self.plot.current_frame
             stream = self.streams[0]
             if len(msg['index']):
-                selection = el.iloc[msg['index']]
-                values = selection.dimension_values(stream.dimension)
-                msg['values'] = list(values)
+                selection = el.data.iloc[msg['index']]
+                dim = el.get_dimension(stream.dimension)
+                msg['values'] = list(selection[dim.name])
             else:
                 msg['values'] = []
         return msg

--- a/lsst_dashboard/visits_plot.py
+++ b/lsst_dashboard/visits_plot.py
@@ -33,7 +33,8 @@ def visits_plot_per_filter(dsets_filter, metrics, filt, statistic, errors=[], se
             if (filt, metric) in selections:
                 stream = selections[(filt, metric)]
                 stream.source = plot_metric.get(1)
-                plot_metric.get(1).opts(selected=stream.index)
+                if stream.index:
+                    plot_metric.get(1).opts(selected=stream.index)
             plot_all = plot_all * plot_metric if plot_all else plot_metric
         except:
             errors.append(metric)


### PR DESCRIPTION
Allows selecting individual visits on the line plot and toggling between coadd view and visit view.

ToDo:

- [x] Load visit data when visit is selected
- [x] Decide whether toggle should be per filter or across filters (do all visits appear in all filters?) 

![Screen Shot 2020-05-11 at 2 51 44 PM](https://user-images.githubusercontent.com/1550771/81563733-f7345180-9396-11ea-8bb4-997c2a97de34.png)

Closes https://github.com/Quansight/lsst_dashboard/issues/110