### PR TITLE
Update to dask-jobqueue 0.7.1/distributed 2.16

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,15 +9,15 @@ channels:
 dependencies:
     - python>=3.7
     - param
-    - panel>=0.8
-    - holoviews
+    - panel>=0.9.5
+    - holoviews>=1.13.3a1
     - hvplot
     - geoviews
     - numpy
     - pandas
     - dask
-    - distributed
-    - dask-jobqueue
+    - distributed>=2.16
+    - dask-jobqueue>=0.7.1
     - datashader
     - kartothek
     - colorcet

--- a/lsst_dashboard/cli.py
+++ b/lsst_dashboard/cli.py
@@ -64,9 +64,11 @@ def launch_dask_cluster(queue, nodes, localcluster):
             cores=24,
             processes=procs_per_node,
             memory='128GB',
-            scheduler_port=scheduler_port,
+            scheduler_options={
+                'port': scheduler_port,
+                'dashboard_address':f":{dask_dashboard_port}"
+                },
             extra=[f'--worker-port {":".join(str(p) for p in DASK_ALLOWED_PORTS)}'],
-            dashboard_address=f":{dask_dashboard_port}",
         )
 
         print(f'...requesting {nodes} nodes')


### PR DESCRIPTION
@timothydmorton This pr make the changes needed to use the release versions of dask-jobqueue and distributed that will enable using multiple processes per node. We should aslo add these version numbers as min reqs in the requirements.txt file that is in the branch you are working on.